### PR TITLE
v2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-FreeRTOS-FAT-CLI-for-RPi-Pico  
-v2.10.0
+# FreeRTOS-FAT-CLI-for-RPi-Pico  
+# v2.11.0
 =============================
 ## C/C++ Library for SD Cards on the Pico
 
@@ -16,6 +16,11 @@ and/or a 4-bit Secure Digital Input Output (SDIO) driver derived from
 It is wrapped up in a complete runnable project, with a little command line interface, some self tests, and an example data logging application.
 
 ## What's new
+### v2.11.0
+* Add `spi_mode` to the hardware configuration.
+For SPI attached cards, SPI Mode 3 can significantly improve performance.
+See [SPI Controller Configuration](#spi-controller-configuration).
+* Additional performance improvements in SPI driver.
 ### v2.10.0
 * Make timeouts configurable. See [Timeouts](#timeouts).
 ### v2.9.0
@@ -171,7 +176,7 @@ Writing and reading a file of 200 MiB of psuedorandom data on the same
 [Silicon Power 3D NAND U1 32GB microSD card](https://www.amazon.com/gp/product/B07RSXSYJC/) inserted into a 
 [Pico Stackable, Plug & Play SD Card Expansion Module](https://forums.raspberrypi.com/viewtopic.php?t=356864)
 at the default Pico system clock frequency (`clk_sys`) of 125 MHz, `MinSizeRel` build, using the command
-[big_file_test bf 200 7](#appendix-b-operation-of-command_line-example)
+[big_file_test bf 200 ](#appendix-b-operation-of-command_line-example)*x*.
 once on SPI and one on SDIO.
 
 * SDIO, baud rate 31,250,000 Hz:
@@ -182,13 +187,13 @@ once on SPI and one on SDIO.
     * Elapsed seconds 16.0
     * Transfer rate 12.5 MiB/s (13.1 MB/s), or 12784 KiB/s (13091 kB/s) (104729 kbit/s)
 
-* SPI, baud rate 20,833,333 Hz:
-  * Writing
-    * Elapsed seconds 117
-    * Transfer rate 1.70 MiB/s (1.79 MB/s), or 1746 KiB/s (1788 kB/s) (14302 kbit/s)
-  * Reading
-    * Elapsed seconds 117
-    * Transfer rate 1.71 MiB/s (1.79 MB/s), or 1746 KiB/s (1788 kB/s) (14303 kbit/s)
+* SPI, baud rate, baud rate 31,250,000 Hz:
+  * Writing...
+    * Elapsed seconds 86.5
+    * Transfer rate 2.31 MiB/s (2.42 MB/s), or 2366 KiB/s (2423 kB/s) (19386 kbit/s)
+  * Reading...
+    * Elapsed seconds 90.4
+    * Transfer rate 2.21 MiB/s (2.32 MB/s), or 2265 KiB/s (2320 kB/s) (18557 kbit/s)
 
 Results from a
 [port](https://github.com/carlk3/FreeRTOS-FAT-CLI-for-RPi-Pico/blob/master/examples/command_line/tests/bench.c)
@@ -211,20 +216,20 @@ of
   13306.8,4940,4907,4918
   ...
   ```
-* SPI, baud rate 20,833,333 Hz:
+* SPI, baud rate 31,250,000 Hz:
   ```
   ...
   write speed and latency
   speed,max,min,avg
   KB/Sec,usec,usec,usec
-  1744.7,74130,36312,37557
-  1757.6,74078,36285,37283
+  2463.8,41867,26204,26594
+  2491.9,26558,26175,26296
   ...
   read speed and latency
   speed,max,min,avg
   KB/Sec,usec,usec,usec
-  1791.8,36620,36533,36568
-  1791.8,36637,36523,36568
+  2359.5,27882,27664,27766
+  2361.7,27847,27675,27758
   ...
   ```
 ### Data Striping
@@ -578,21 +583,33 @@ If false, the GPIO's drive strength will be implicitly set to 4 mA.
 An instance of `spi_t` describes the configuration of one RP2040 SPI controller.
 ```C
 typedef struct spi_t {
-    spi_inst_t *hw_inst;  // SPI HW
+    spi_inst_t *hw_inst;    // SPI HW
     uint miso_gpio;  // SPI MISO GPIO number (not pin number)
     uint mosi_gpio;
     uint sck_gpio;
     uint baud_rate;
+
+    /* The different modes of the Motorola SPI protocol are:
+    - Mode 0: When CPOL and CPHA are both 0, data sampled at the leading rising edge of the
+    clock pulse and shifted out on the falling edge. This is the most common mode for SPI bus
+    communication.
+    - Mode 1: When CPOL is 0 and CPHA is 1, data sampled at the trailing falling edge and
+    shifted out on the rising edge.
+    - Mode 2: When CPOL is 1 and CPHA is 0, data sampled at the leading falling edge
+    and shifted out on the rising edge.
+    - Mode 3: When CPOL is 1 and CPHA is 1, data sampled at the trailing rising edge and
+    shifted out on the falling edge. */
+    uint spi_mode;
+
     uint DMA_IRQ_num; // DMA_IRQ_0 or DMA_IRQ_1
     bool use_exclusive_DMA_IRQ_handler;
     bool no_miso_gpio_pull_up;
 
-    /* Drive strength levels for GPIO outputs.
+    /* Drive strength levels for GPIO outputs:
         GPIO_DRIVE_STRENGTH_2MA, 
         GPIO_DRIVE_STRENGTH_4MA, 
         GPIO_DRIVE_STRENGTH_8MA,
-        GPIO_DRIVE_STRENGTH_12MA
-    */
+        GPIO_DRIVE_STRENGTH_12MA */
     bool set_drive_strength;
     enum gpio_drive_strength mosi_gpio_drive_strength;
     enum gpio_drive_strength sck_gpio_drive_strength;
@@ -605,7 +622,7 @@ typedef struct spi_t {
 * `miso_gpio` SPI Master In, Slave Out (MISO) (also called "CIPO" or "Peripheral's SDO") GPIO number. This is connected to the SD card's Data Out (DO).
 * `mosi_gpio` SPI Master Out, Slave In (MOSI) (also called "COPI", or "Peripheral's SDI") GPIO number. This is connected to the SD card's Data In (DI).
 * `sck_gpio` SPI Serial Clock GPIO number. This is connected to the SD card's Serial Clock (SCK).
-* `baud_rate` Frequency of the SPI Serial Clock, in Hertz. The default is 10 MHz.
+* `baud_rate` Frequency of the SPI Serial Clock, in Hertz. The default is `clk_sys` / 12.
   This is ultimately passed to the SDK's [spi_set_baudrate](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#ga37f4c04ce4165ac8c129226336a0b66c). This applies a hardware prescale and a post-divide to the *Peripheral clock* (`clk_peri`) (see section **4.4.2.3.** *Clock prescaler* in [RP2040 Datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf)). 
   The *Peripheral clock* typically,
   but not necessarily, runs from `clk_sys`.
@@ -618,11 +635,16 @@ typedef struct spi_t {
   ```C
       .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
   ```
-  If you ask for 14000000, you'll actually get 12500000 Hz.
+  If you ask for 14,000,000 Hz, you'll actually get 12,500,000 Hz.
   The actual baud rate will be printed out if `USE_DBG_PRINTF` (see [Messages from the SD card driver](#messages-from-the-sd-card-driver)) is defined at compile time.
   The higher the baud rate, the faster the data transfer.
-  However, the hardware might limit the usable baud rate.
+  At the maximum `clk_peri` frequency on RP2040 of 133MHz, the maximum peak bit rate in master mode is 62.5Mbps.
+  However, the hardware (including the SD card) might limit the usable baud rate.
   See [Pull Up Resistors and other electrical considerations](#pull-up-resistors-and-other-electrical-considerations).
+* `spi_mode` 0, 1, 2, or 3. 0 is the most common mode for SPI bus slave communication.
+This controls the Motorola SPI frame format CPOL, clock polarity; and CPHA, clock phase.
+SPI mode 0 (CPOL=0, CPHA=0) is the proper setting to control MMC/SDC, but mode 3 (CPOL=1, CPHA=1) also works as well in most cases[^6].
+Mode 3 can be around 15% faster than mode 0, probably due to quirks of the ARM PrimeCell Synchronous Serial Port in the RP2040.
 * `DMA_IRQ_num` Which IRQ to use for DMA. Defaults to DMA_IRQ_0. Set this to avoid conflicts with any exclusive DMA IRQ handlers that might be elsewhere in the system.
 * `use_exclusive_DMA_IRQ_handler` If true, the IRQ handler is added with the SDK's `irq_set_exclusive_handler`. The default is to add the handler with `irq_add_shared_handler`, so it's not exclusive. 
 * `no_miso_gpio_pull_up` According to the standard, an SD card's DO MUST be pulled up (at least for the old MMC cards). 
@@ -988,10 +1010,13 @@ or
 
 ## Appendix D: Performance Tuning Tips
 Obviously, if possible, use 4-bit SDIO instead of 1-bit SPI.
-(See [Choosing the Interface Type(s)](#choosing-the-interface-types)).
+(See [Choosing the Interface Type(s)](#choosing-the-interface-types).)
 
 Obviously, set the baud rate as high as you can. (See
 [Customizing for the Hardware Configuration](#customizing-for-the-hardware-configuration)).
+
+If you are using SPI, try SPI mode 3 (CPOL=1, CPHA=1) instead of 0 (CPOL=0, CPHA=0). (See
+[SPI Controller Configuration](#spi-controller-configuration).) This could buy a 15% speed boost.
 
 TL;DR: In general, it is much faster to transfer a given number of bytes in one large write (or read) 
 than to transfer the same number of bytes in multiple smaller writes (or reads). 
@@ -1110,7 +1135,11 @@ You can swap the commenting to enable tracing of what's happening in that file.
 * Better yet, go to somwhere like [JLCPCB](https://jlcpcb.com/) and get a printed circuit board!
 
 
-[^3]: In my experience, the Card Detect switch on these doesn't work worth a damn. This might not be such a big deal, because according to [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/) the Chip Select (CS) line can be used for Card Detection: "At power up this line has a 50KOhm pull up enabled in the card... For Card detection, the host detects that the line is pulled high." 
+[^3]: In my experience, the Card Detect switch on these doesn't work worth a damn. This might not be such a big deal, because according to [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/) the Chip Select (CS) line can be used for Card Detection: "At power up this line has a 50KOhm pull up enabled in the card... For Card detection, the host detects that the line is pulled high."
 However, the Adafruit card has it's own 47 kΩ pull up on CS - Card Detect / Data Line [Bit 3], rendering it useless for Card Detection.
+
 [^4]: [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/)
+
 [^5]: Rationale: Instances of `sd_spi_if_t` or `sd_sdio_if_t` are separate objects instead of being embedded in `sd_card_t` objects because `sd_sdio_if_t` carries a lot of state information with it (including things like data buffers). The union of the two types has the size of the largest type, which would result in a lot of wasted space in instances of `sd_spi_if_t`. I had another solution using `malloc`, but some people are frightened of `malloc` in embedded systems.
+
+[^6]: *SPI Mode* in [How to Use MMC/SDC](http://elm-chan.org/docs/mmc/mmc_e.html#spimode)

--- a/examples/command_line/config/dev_brd.hw_config.c
+++ b/examples/command_line/config/dev_brd.hw_config.c
@@ -56,7 +56,7 @@ static spi_t spis[] = {  // One for each RP2040 SPI component used
         // .baud_rate = 125 * 1000 * 1000 / 10 // 12500000 Hz
         // .baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
         .baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
-        // .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
+        //.baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
     },
     {   // spis[1]
         .hw_inst = spi1,  // RP2040 SPI component
@@ -72,7 +72,7 @@ static spi_t spis[] = {  // One for each RP2040 SPI component used
         //.baud_rate = 125 * 1000 * 1000 / 10  // 12500000 Hz
         //.baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
         .baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
-        // .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
+        //.baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
     }
 };
 

--- a/examples/command_line/config/exp_mod_A_SPI.hw_config.c
+++ b/examples/command_line/config/exp_mod_A_SPI.hw_config.c
@@ -41,8 +41,8 @@ static spi_t spi  = {  // One for each RP2040 SPI component used
     .use_exclusive_DMA_IRQ_handler = true,
     //.baud_rate = 125 * 1000 * 1000 / 10  // 12500000 Hz
     //.baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
-    .baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
-    //.baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
+    //.baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
+    .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
 };
 
 /* SPI Interface */

--- a/examples/command_line/config/exp_mod_A_SPI.hw_config.c
+++ b/examples/command_line/config/exp_mod_A_SPI.hw_config.c
@@ -39,6 +39,7 @@ static spi_t spi  = {  // One for each RP2040 SPI component used
     .no_miso_gpio_pull_up = false,
     .DMA_IRQ_num = DMA_IRQ_0,
     .use_exclusive_DMA_IRQ_handler = true,
+    .spi_mode = 3,
     //.baud_rate = 125 * 1000 * 1000 / 10  // 12500000 Hz
     //.baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
     //.baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz

--- a/examples/command_line/config/hw_config.c
+++ b/examples/command_line/config/hw_config.c
@@ -54,9 +54,9 @@ static spi_t spis[] = {  // One for each RP2040 SPI component used
         .no_miso_gpio_pull_up = true,
         .DMA_IRQ_num = DMA_IRQ_0,
         // .baud_rate = 125 * 1000 * 1000 / 10 // 12500000 Hz
-        .baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
-        //.baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
-        // .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
+        // .baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
+        .baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
+        //.baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
     },
     {   // spis[1]
         .hw_inst = spi1,  // RP2040 SPI component
@@ -70,8 +70,8 @@ static spi_t spis[] = {  // One for each RP2040 SPI component used
         .DMA_IRQ_num = DMA_IRQ_0,
         //.baud_rate = 125 * 1000 * 1000 / 12
         //.baud_rate = 125 * 1000 * 1000 / 10  // 12500000 Hz
-        .baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
-        //.baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
+        //.baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
+        .baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
         //.baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
     }
 };

--- a/src/FreeRTOS+FAT+CLI/CMakeLists.txt
+++ b/src/FreeRTOS+FAT+CLI/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(FreeRTOS+FAT+CLI INTERFACE
         src/FreeRTOS_strerror.c
         src/FreeRTOS_time.c
         src/my_debug.c
+        src/sd_timeouts.c
         src/util.c
 )
 target_link_libraries(FreeRTOS+FAT+CLI INTERFACE

--- a/src/FreeRTOS+FAT+CLI/include/crc.h
+++ b/src/FreeRTOS+FAT+CLI/include/crc.h
@@ -45,7 +45,7 @@ specific language governing permissions and limitations under the License.
  * @return The calculated checksum.
  */
 __attribute__((optimize("Ofast")))
-static inline char crc7(const uint8_t* data, int length) {
+static inline char crc7(uint8_t const *data, int const length) {
     extern const char m_Crc7Table[];    
 	char crc = 0;
 	for (int i = 0; i < length; i++) {

--- a/src/FreeRTOS+FAT+CLI/include/delays.h
+++ b/src/FreeRTOS+FAT+CLI/include/delays.h
@@ -1,4 +1,9 @@
-
+/*
+ * delays.h
+ *
+ *  Created on: Apr 25, 2022
+ *      Author: carlk
+ */
 /* Using millis() or micros() for timeouts
 
 For example, 
@@ -51,6 +56,10 @@ call to millis() returns 0xFFFFFFFF:
 #include "FreeRTOS.h"
 #include "task.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline uint32_t millis() {
     __COMPILER_BARRIER();
     return xTaskGetTickCount() * (1000 / configTICK_RATE_HZ);
@@ -66,3 +75,8 @@ static inline uint64_t micros() {
     return to_us_since_boot(get_absolute_time());
     __COMPILER_BARRIER();
 }
+
+#ifdef __cplusplus
+}
+#endif
+/* [] END OF FILE */

--- a/src/FreeRTOS+FAT+CLI/include/my_debug.h
+++ b/src/FreeRTOS+FAT+CLI/include/my_debug.h
@@ -60,7 +60,7 @@ int error_message_printf_plain(const char *fmt, ...) __attribute__ ((format (__p
 int debug_message_printf(const char *func, int line, const char *fmt, ...)
     __attribute__((format(__printf__, 3, 4)));
 #ifndef DBG_PRINTF
-#  if defined(USE_DBG_PRINTF) && USE_DBG_PRINTF && !defined(NDEBUG)
+#  if defined(USE_DBG_PRINTF) && USE_DBG_PRINTF // && !defined(NDEBUG)
 #    define DBG_PRINTF(fmt, ...) debug_message_printf(__func__, __LINE__, fmt, ##__VA_ARGS__)
 #  else
 #    define DBG_PRINTF(fmt, ...) (void)0

--- a/src/FreeRTOS+FAT+CLI/include/my_debug.h
+++ b/src/FreeRTOS+FAT+CLI/include/my_debug.h
@@ -22,12 +22,6 @@ specific language governing permissions and limitations under the License.
 extern "C" {
 #endif
 
-#ifdef ANALYZER
-#  define TRIG() gpio_put(15, 1)  // DEBUG
-#else 
-#  define TRIG()
-#endif
-
 /* USE_PRINTF
 If this is defined and not zero, 
 these message output functions will use the Pico SDK's stdout.
@@ -80,9 +74,8 @@ void my_assert_func(const char *file, int line, const char *func, const char *pr
 #ifdef NDEBUG           /* required by ANSI standard */
 #  define myASSERT(__e) ((void)0)
 #else
-#  define myASSERT(__e) \
-    { ((__e) ? (void)0 : my_assert_func(__func__, __LINE__, __func__, #__e)); }
-#endif    
+#  define myASSERT(__e) ((__e) ? (void)0 : my_assert_func(__FILE__, __LINE__, __func__, #__e))
+#endif
 
 int task_printf(const char *pcFormat, ...) __attribute__((format(__printf__, 1, 2)));
 

--- a/src/FreeRTOS+FAT+CLI/include/sd_timeouts.h
+++ b/src/FreeRTOS+FAT+CLI/include/sd_timeouts.h
@@ -1,0 +1,23 @@
+
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t sd_command;
+    unsigned sd_command_retries;
+    unsigned sd_lock;
+    unsigned sd_spi_read;
+    unsigned sd_spi_write;
+    unsigned sd_spi_write_read;
+    unsigned spi_lock;
+    unsigned rp2040_sdio_command_R1;
+    unsigned rp2040_sdio_command_R2;
+    unsigned rp2040_sdio_command_R3;
+    unsigned rp2040_sdio_rx_poll;
+    unsigned rp2040_sdio_tx_poll;
+    unsigned sd_sdio_begin;
+    unsigned sd_sdio_stopTransmission;
+} sd_timeouts_t;
+
+extern sd_timeouts_t sd_timeouts;

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/rp2040_sdio.c
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/rp2040_sdio.c
@@ -15,7 +15,11 @@
 #include "hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
-#include "RP2040.h"
+#if PICO_RP2040
+#  include "RP2040.h"
+#else
+#  include "RP2350.h"
+#endif
 //
 #include "dma_interrupts.h"
 #include "hw_config.h"

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/rp2040_sdio.c
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/rp2040_sdio.c
@@ -23,6 +23,7 @@
 #include "rp2040_sdio.pio.h"
 #include "delays.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 #include "my_debug.h"
 #include "util.h"
 //
@@ -167,7 +168,7 @@ sdio_status_t rp2040_sdio_command_R1(sd_card_t *sd_card_p, uint8_t command, uint
     uint32_t wait_words = response ? 2 : 1;
     while (pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM) < wait_words)
     {
-        if ((uint32_t)(millis() - start) > 5)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R1)
         {
             if (command != 8) // Don't log for missing SD card
             {
@@ -244,7 +245,7 @@ sdio_status_t rp2040_sdio_command_R2(const sd_card_t *sd_card_p, uint8_t command
     uint32_t start = millis();
     while (dma_channel_is_busy(SDIO_DMA_CH))
     {
-        if ((uint32_t)(millis() - start) > 2)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R2)
         {
             azdbg("Timeout waiting for response in rp2040_sdio_command_R2(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)STATE.pio_cmd_clk_offset,
@@ -311,7 +312,7 @@ sdio_status_t rp2040_sdio_command_R3(sd_card_t *sd_card_p, uint8_t command, uint
     uint32_t start = millis();
     while (pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM) < 2)
     {
-        if ((uint32_t)(millis() - start) > 2)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R3)
         {
             azdbg("Timeout waiting for response in rp2040_sdio_command_R3(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)STATE.pio_cmd_clk_offset,
@@ -466,7 +467,7 @@ sdio_status_t rp2040_sdio_rx_poll(sd_card_t *sd_card_p, size_t block_size_words)
         else
             return SDIO_ERR_DATA_CRC;
     }
-    else if (millis() - STATE.transfer_start_time >= 1000)
+    else if (millis() - STATE.transfer_start_time >= sd_timeouts.rp2040_sdio_rx_poll)
     {
         azdbg("rp2040_sdio_rx_poll() timeout, "
             "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_DATA_SM) - (int)STATE.pio_data_rx_offset,
@@ -700,7 +701,7 @@ sdio_status_t rp2040_sdio_tx_poll(sd_card_t *sd_card_p, uint32_t *bytes_complete
         rp2040_sdio_stop(sd_card_p);
         return STATE.wr_status;
     }
-    else if (millis() - STATE.transfer_start_time >= 5000)  // CK3: increased timeout
+    else if (millis() - STATE.transfer_start_time >= sd_timeouts.rp2040_sdio_tx_poll)
     {
         EMSG_PRINTF("rp2040_sdio_tx_poll() timeout\n");
         DBG_PRINTF("rp2040_sdio_tx_poll() timeout, "

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/sd_card_sdio.c
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SDIO/sd_card_sdio.c
@@ -28,6 +28,7 @@
 #include "rp2040_sdio.pio.h"  // build\build\rp2040_sdio.pio.h
 #include "sd_card_constants.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 #include "SdioCard.h"
 #include "util.h"
 
@@ -129,7 +130,7 @@ bool sd_sdio_begin(sd_card_t *sd_card_p)
             return false;
         }
 
-        if ((uint32_t)(millis() - start) > 1000)
+        if ((uint32_t)(millis() - start) > sd_timeouts.sd_sdio_begin)
         {
             EMSG_PRINTF("SDIO card initialization timeout\n");
             return false;

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/my_spi.h
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/my_spi.h
@@ -14,6 +14,11 @@ specific language governing permissions and limitations under the License.
 
 #pragma once
 
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+//
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -26,10 +31,8 @@ specific language governing permissions and limitations under the License.
 #include "hardware/gpio.h"
 #include "hardware/irq.h"
 #include "hardware/spi.h"
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "semphr.h"
-#include "task.h"
+//
+#include "sd_timeouts.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,7 +82,7 @@ bool my_spi_init(spi_t *spi_p);
 
 static inline void spi_lock(spi_t *spi_p) {
     configASSERT(spi_p);
-    BaseType_t rc = xSemaphoreTake(spi_p->mutex, pdMS_TO_TICKS(8000));
+    BaseType_t rc = xSemaphoreTake(spi_p->mutex, pdMS_TO_TICKS(sd_timeouts.spi_lock));
     if (pdFALSE == rc) {
         DBG_PRINTF("Timed out. Lock is held by %s.\n",
                    xSemaphoreGetMutexHolder(spi_p->mutex)

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/my_spi.h
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/my_spi.h
@@ -32,6 +32,7 @@ specific language governing permissions and limitations under the License.
 #include "hardware/irq.h"
 #include "hardware/spi.h"
 //
+#include "my_debug.h"
 #include "sd_timeouts.h"
 
 #ifdef __cplusplus
@@ -47,16 +48,28 @@ typedef struct spi_t {
     uint mosi_gpio;
     uint sck_gpio;
     uint baud_rate;
+
+    /* The different modes of the Motorola SPI protocol are:
+    - Mode 0: When CPOL and CPHA are both 0, data sampled at the leading rising edge of the
+    clock pulse and shifted out on the falling edge. This is the most common mode for SPI bus
+    communication.
+    - Mode 1: When CPOL is 0 and CPHA is 1, data sampled at the trailing falling edge and
+    shifted out on the rising edge.
+    - Mode 2: When CPOL is 1 and CPHA is 0, data sampled at the leading falling edge
+    and shifted out on the rising edge.
+    - Mode 3: When CPOL is 1 and CPHA is 1, data sampled at the trailing rising edge and
+    shifted out on the falling edge. */
+    uint spi_mode;
+
     uint DMA_IRQ_num; // DMA_IRQ_0 or DMA_IRQ_1
     bool use_exclusive_DMA_IRQ_handler;
     bool no_miso_gpio_pull_up;
 
-    /* Drive strength levels for GPIO outputs.
+    /* Drive strength levels for GPIO outputs:
         GPIO_DRIVE_STRENGTH_2MA, 
         GPIO_DRIVE_STRENGTH_4MA, 
         GPIO_DRIVE_STRENGTH_8MA,
-        GPIO_DRIVE_STRENGTH_12MA
-    */
+        GPIO_DRIVE_STRENGTH_12MA */
     bool set_drive_strength;
     enum gpio_drive_strength mosi_gpio_drive_strength;
     enum gpio_drive_strength sck_gpio_drive_strength;
@@ -64,8 +77,6 @@ typedef struct spi_t {
     /* The following fields are not part of the configuration. They are dynamically assigned. */
     uint tx_dma;
     uint rx_dma;
-
-    /* The following fields are not part of the configuration. They are dynamically assigned. */
     dma_channel_config tx_dma_cfg;
     dma_channel_config rx_dma_cfg;
     SemaphoreHandle_t mutex;    

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_card_spi.c
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_card_spi.c
@@ -181,6 +181,7 @@
 #include "sd_card.h"
 #include "sd_card_constants.h"
 #include "sd_spi.h"
+#include "sd_timeouts.h"
 #include "util.h"
 //
 #include "sd_card_spi.h"
@@ -320,7 +321,10 @@ static uint8_t sd_cmd_spi(sd_card_t *sd_card_p, cmdSupported cmd, uint32_t arg) 
                 break;
         }
     }
-    sd_spi_transfer(sd_card_p, cmd_packet, NULL, PACKET_SIZE);
+    //sd_spi_transfer(sd_card_p, cmd_packet, NULL, PACKET_SIZE);
+    for (size_t i = 0; i < PACKET_SIZE; i++) {
+        sd_spi_write(sd_card_p, cmd_packet[i]);
+    }
 
     // The received byte immediately following CMD12 is a stuff byte,
     // it should be discarded before receive the response of the CMD12.
@@ -332,7 +336,7 @@ static uint8_t sd_cmd_spi(sd_card_t *sd_card_p, cmdSupported cmd, uint32_t arg) 
     // (NCR), 0 to 8 bytes for SDC
     uint8_t response;
     for (size_t i = 0; i < 0x10; i++) {
-        response = sd_spi_write_read(sd_card_p, SPI_FILL_CHAR);
+        response = sd_spi_read(sd_card_p);
         // Got the response
         if (!(response & R1_RESPONSE_RECV)) {
             break;
@@ -524,9 +528,6 @@ static int chk_CMD13_response(uint32_t response) {
     return status;
 }
 
-#define SD_COMMAND_RETRIES 3    /*!< Times SPI cmd is retried when there is no response */
-#define SD_COMMAND_TIMEOUT 2000 /*!< Timeout in ms for response */
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"
 
@@ -540,7 +541,7 @@ static int chk_CMD13_response(uint32_t response) {
  * @return error code
  *
  * This function sends a command to the SD card and waits for the response.
- * It will retry the command up to SD_COMMAND_RETRIES times if there is no response.
+ * It will retry the command up to sd_timeouts.sd_command_retries times if there is no response.
  * The response is stored in the @p resp variable if it is not NULL.
  * The function will return SD_BLOCK_DEVICE_ERROR_NONE if the command was successful,
  * SD_BLOCK_DEVICE_ERROR_NO_RESPONSE if there was no response,
@@ -556,23 +557,23 @@ static block_dev_err_t sd_cmd(sd_card_t *sd_card_p, const cmdSupported cmd, uint
     myASSERT(0 == gpio_get(sd_card_p->spi_if_p->ss_gpio));
 
     int32_t status = SD_BLOCK_DEVICE_ERROR_NONE;
-    uint32_t response;
+    uint32_t response = 0;
 
     myASSERT(xTaskGetCurrentTaskHandle() == sd_card_p->spi_if_p->spi->owner);
 
     // No need to wait for card to be ready when sending the stop command
     if (CMD12_STOP_TRANSMISSION != cmd && CMD0_GO_IDLE_STATE != cmd) {
-        if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
+        if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
             DBG_PRINTF("Card not ready yet\n");
             return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
         }
     }
-    for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+    for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
         // Send CMD55 for APP command first
         if (isAcmd) {
             response = sd_cmd_spi(sd_card_p, CMD55_APP_CMD, 0x0);
             // Wait for card to be ready after CMD55
-            if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
+            if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
                 DBG_PRINTF("Card not ready yet\n");
             }
         }
@@ -625,19 +626,19 @@ static block_dev_err_t sd_cmd(sd_card_t *sd_card_p, const cmdSupported cmd, uint
             sd_card_p->state.card_type = SDCARD_V2;  // fallthrough
             // Note: No break here, need to read rest of the response
         case CMD58_READ_OCR:  // Response R3
-            response = (sd_spi_write_read(sd_card_p, SPI_FILL_CHAR) << 24);
-            response |= (sd_spi_write_read(sd_card_p, SPI_FILL_CHAR) << 16);
-            response |= (sd_spi_write_read(sd_card_p, SPI_FILL_CHAR) << 8);
-            response |= sd_spi_write_read(sd_card_p, SPI_FILL_CHAR);
+            response = (sd_spi_read(sd_card_p) << 24);
+            response |= (sd_spi_read(sd_card_p) << 16);
+            response |= (sd_spi_read(sd_card_p) << 8);
+            response |= sd_spi_read(sd_card_p);
             DBG_PRINTF("R3/R7: 0x%" PRIx32 "\n", response);
             break;
         case CMD12_STOP_TRANSMISSION:  // Response R1b
         case CMD38_ERASE:
-            sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT);
+            sd_wait_ready(sd_card_p, sd_timeouts.sd_command);
             break;
         case CMD13_SEND_STATUS:  // Response R2
             response <<= 8;
-            response |= sd_spi_write_read(sd_card_p, SPI_FILL_CHAR);
+            response |= sd_spi_read(sd_card_p);
             if (response) status = chk_CMD13_response(response);
         default:;
     }
@@ -746,10 +747,10 @@ static bool sd_wait_token(sd_card_t *sd_card_p, uint8_t token) {
 
     uint32_t start = millis();
     do {
-        if (token == sd_spi_write_read(sd_card_p, SPI_FILL_CHAR)) {
+        if (token == sd_spi_read(sd_card_p)) {
             return true;
         }
-    } while (millis() - start < SD_COMMAND_TIMEOUT);
+    } while (millis() - start < sd_timeouts.sd_command);
 
     DBG_PRINTF("sd_wait_token: timeout\n");
     return false;
@@ -777,7 +778,7 @@ static block_dev_err_t read_bytes(sd_card_t *sd_card_p, uint8_t *buffer, uint32_
 
     // read until start byte (0xFE)
     if (false == sd_wait_token(sd_card_p, SPI_START_BLOCK)) {
-        DBG_PRINTF("%s:%d Read timeout\n", __FILE__, __LINE__);
+        DBG_PRINTF("%s:%d Read timeout\n", __func__, __LINE__);
         return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
     }
     bool ok = sd_spi_transfer(sd_card_p, NULL, buffer, length);
@@ -854,7 +855,7 @@ static block_dev_err_t in_sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
     while (blk_cnt) {
         // read until start byte (0xFE)
         if (!sd_wait_token(sd_card_p, SPI_START_BLOCK)) {
-            DBG_PRINTF("%s:%d Read timeout\n", __FILE__, __LINE__);
+            DBG_PRINTF("%s:%d Read timeout\n", __func__, __LINE__);
             return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
         }
         // read data
@@ -898,7 +899,7 @@ static block_dev_err_t sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
                                       uint32_t data_address, uint32_t num_rd_blks) {
     TRACE_PRINTF("sd_read_blocks(0x%p, 0x%lx, 0x%lx)\n", buffer, data_address, num_rd_blks);
     sd_acquire(sd_card_p);
-    unsigned retries = 3;
+    unsigned retries = sd_timeouts.sd_command_retries;
     block_dev_err_t status;
     do {
         status = in_sd_read_blocks(sd_card_p, buffer, data_address, num_rd_blks);
@@ -1007,7 +1008,7 @@ static block_dev_err_t send_block(sd_card_t *sd_card_p, const uint8_t *buffer, u
     block_dev_err_t rc = SD_BLOCK_DEVICE_ERROR_NONE;
 
     // Check the response token
-    response = sd_spi_write_read(sd_card_p, SPI_FILL_CHAR);
+    response = sd_spi_read(sd_card_p);
 
     // Only CRC and general write error are communicated via response token
     if ((response & SPI_DATA_RESPONSE_MASK) != SPI_DATA_ACCEPTED) {
@@ -1034,8 +1035,8 @@ static block_dev_err_t send_block(sd_card_t *sd_card_p, const uint8_t *buffer, u
         rc = SD_BLOCK_DEVICE_ERROR_WRITE;
     }
     // Wait while card is busy programming
-    if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
-        DBG_PRINTF("%s:%d: Card not ready yet\n", __FILE__, __LINE__);
+    if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
+        DBG_PRINTF("%s:%d: Card not ready yet\n", __func__, __LINE__);
         rc = SD_BLOCK_DEVICE_ERROR_WRITE;
     }
     return rc;
@@ -1165,7 +1166,7 @@ static block_dev_err_t stop_wr_tran(sd_card_t *sd_card_p) {
     the host via the data-response token is CRC.
     */
 
-    if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
+    if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
         DBG_PRINTF("Card not ready yet\n");
     }
 
@@ -1269,9 +1270,9 @@ static block_dev_err_t sd_write_blocks(sd_card_t *sd_card_p, uint8_t const buffe
         status = write_block(sd_card_p, buffer, data_address);
     } else {
         // If writing multiple blocks, retry the operation until it succeeds or reaches the maximum number of retries
-        unsigned retries = SD_COMMAND_RETRIES;
+        unsigned retries = sd_timeouts.sd_command_retries;
         do {
-            if (retries < SD_COMMAND_RETRIES) DBG_PRINTF("Retrying\n");
+            if (retries < sd_timeouts.sd_command_retries) DBG_PRINTF("Retrying\n");
             status = in_sd_write_blocks(sd_card_p, &buffer, &data_address, &num_wrt_blks);
             if (SD_BLOCK_DEVICE_ERROR_WRITE == status)
                 DBG_PRINTF("%s: status=0x%x data_address=%lu num_wrt_blks=%lu\n", sd_card_p->device_name, status, data_address, num_wrt_blks);
@@ -1455,7 +1456,7 @@ static block_dev_err_t sd_init_medium(sd_card_t *sd_card_p) {
     uint32_t start = millis();
     do {
         status = sd_cmd(sd_card_p, ACMD41_SD_SEND_OP_COND, arg, true, &response);
-    } while (response & R1_IDLE_STATE && millis() - start < SD_COMMAND_TIMEOUT);
+    } while (response & R1_IDLE_STATE && millis() - start < sd_timeouts.sd_command);
     // Initialization complete: ACMD41 successful
     if ((SD_BLOCK_DEVICE_ERROR_NONE != status) || (0x00 != response)) {
         sd_card_p->state.card_type = CARD_UNKNOWN;
@@ -1532,7 +1533,7 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
         if (sd_wait_ready(sd_card_p, 0)) {
             // DO has been released, try to get status
             uint32_t response;
-            for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+            for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
                 // Send command over SPI interface
                 response = sd_cmd_spi(sd_card_p, CMD13_SEND_STATUS, 0);
                 if (R1_NO_RESPONSE != response) {
@@ -1563,7 +1564,7 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
         if (sd_wait_ready(sd_card_p, 0)) {
             // DO has been released, try to make SD card go idle
             uint32_t response;
-            for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+            for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
                 // Send command over SPI interface
                 response = sd_cmd_spi(sd_card_p, CMD0_GO_IDLE_STATE, 0);
                 if (R1_NO_RESPONSE != response) {

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_spi.h
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_spi.h
@@ -24,6 +24,7 @@ specific language governing permissions and limitations under the License.
 #include "delays.h"
 #include "my_spi.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 
 #ifdef NDEBUG
 #pragma GCC diagnostic ignored "-Wunused-variable"
@@ -53,7 +54,7 @@ static inline uint8_t sd_spi_read(sd_card_t *sd_card_p) {
     uint8_t received = SPI_FILL_CHAR;
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(1000))
+           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_read))
         tight_loop_contents();
     configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, SPI_FILL_CHAR, &received, 1);
@@ -66,7 +67,7 @@ static inline void sd_spi_write(sd_card_t *sd_card_p, const uint8_t value) {
                  xSemaphoreGetMutexHolder(sd_card_p->spi_if_p->spi->mutex));
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(1000))
+           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_write))
         tight_loop_contents();
     configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_write_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, 1);
@@ -78,7 +79,7 @@ static inline uint8_t sd_spi_write_read(sd_card_t *sd_card_p, const uint8_t valu
     uint8_t received = SPI_FILL_CHAR;
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(1000))
+           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_write_read))
         tight_loop_contents();
     configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_write_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, &received, 1);

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_spi.h
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/SPI/sd_spi.h
@@ -22,6 +22,7 @@ specific language governing permissions and limitations under the License.
 #include "pico/stdlib.h"
 //
 #include "delays.h"
+#include "my_debug.h"
 #include "my_spi.h"
 #include "sd_card.h"
 #include "sd_timeouts.h"
@@ -49,41 +50,41 @@ synchronization problems.
 void sd_spi_send_initializing_sequence(sd_card_t *sd_card_p);
 
 static inline uint8_t sd_spi_read(sd_card_t *sd_card_p) {
-    configASSERT(xTaskGetCurrentTaskHandle() ==
+    myASSERT(xTaskGetCurrentTaskHandle() ==
                  xSemaphoreGetMutexHolder(sd_card_p->spi_if_p->spi->mutex));
     uint8_t received = SPI_FILL_CHAR;
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_read))
+           millis() - start < sd_timeouts.sd_spi_read)
         tight_loop_contents();
-    configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, SPI_FILL_CHAR, &received, 1);
-    configASSERT(1 == num);
+    myASSERT(1 == num);
     return received;
 }
 
 static inline void sd_spi_write(sd_card_t *sd_card_p, const uint8_t value) {
-    configASSERT(xTaskGetCurrentTaskHandle() ==
+    myASSERT(xTaskGetCurrentTaskHandle() ==
                  xSemaphoreGetMutexHolder(sd_card_p->spi_if_p->spi->mutex));
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_write))
+           millis() - start < sd_timeouts.sd_spi_write)
         tight_loop_contents();
-    configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_write_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, 1);
-    configASSERT(1 == num);
+    myASSERT(1 == num);
 }
 static inline uint8_t sd_spi_write_read(sd_card_t *sd_card_p, const uint8_t value) {
-    configASSERT(xTaskGetCurrentTaskHandle() ==
+    myASSERT(xTaskGetCurrentTaskHandle() ==
                  xSemaphoreGetMutexHolder(sd_card_p->spi_if_p->spi->mutex));
     uint8_t received = SPI_FILL_CHAR;
     uint32_t start = millis();
     while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
-           millis() - start < pdMS_TO_TICKS(sd_timeouts.sd_spi_write_read))
+           millis() - start < sd_timeouts.sd_spi_write_read)
         tight_loop_contents();
-    configASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_write_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, &received, 1);
-    configASSERT(1 == num);
+    myASSERT(1 == num);
     return received;
 }
 

--- a/src/FreeRTOS+FAT+CLI/portable/RP2040/sd_card.c
+++ b/src/FreeRTOS+FAT+CLI/portable/RP2040/sd_card.c
@@ -27,6 +27,7 @@ specific language governing permissions and limitations under the License.
 #include "my_debug.h"
 #include "sd_card_constants.h"
 #include "sd_regs.h"
+#include "sd_timeouts.h"
 #include "util.h"
 //
 #include "sd_card.h"
@@ -39,7 +40,7 @@ static bool driver_initialized;
 // An SD card can only do one thing at a time.
 void sd_lock(sd_card_t *sd_card_p) {
     myASSERT(sd_card_p);
-    BaseType_t rc = xSemaphoreTake(sd_card_p->state.mutex, pdMS_TO_TICKS(16000));
+    BaseType_t rc = xSemaphoreTake(sd_card_p->state.mutex, pdMS_TO_TICKS(sd_timeouts.sd_lock));
     if (pdFALSE == rc) {
         DBG_PRINTF("Timed out. Lock is held by %s.\n",
                    xSemaphoreGetMutexHolder(sd_card_p->state.mutex)

--- a/src/FreeRTOS+FAT+CLI/src/FreeRTOS_time.c
+++ b/src/FreeRTOS+FAT+CLI/src/FreeRTOS_time.c
@@ -20,6 +20,7 @@ specific language governing permissions and limitations under the License.
 #include "hardware/rtc.h"
 #include "pico/stdio.h"
 #include "pico/stdlib.h"
+#include "pico/types.h"
 //
 #include "util.h"  // calculate_checksum
 //
@@ -67,7 +68,7 @@ time_t FreeRTOS_time(time_t *pxTime) {
 
 static TimerHandle_t TimeUpdateTimer;
 
-static void TimeUpdateTimerCallback(TimerHandle_t xTimer) {
+static void TimeUpdateTimerCallback(TimerHandle_t) {
     update_epochtime();
 }
 

--- a/src/FreeRTOS+FAT+CLI/src/crc.c
+++ b/src/FreeRTOS+FAT+CLI/src/crc.c
@@ -370,10 +370,10 @@ static uint16_t crc16ibm_3740_word(uint16_t crc, void const *mem, size_t len) {
 
 uint16_t crc16(uint8_t const *data, int const length)
 {
+	//Calculate the CRC16 checksum for the specified data block
 	unsigned short crc = 0;
 	//Return the calculated checksum
 	return crc16ibm_3740_word(crc, data, length);
 }
-
 
 /* [] END OF FILE */

--- a/src/FreeRTOS+FAT+CLI/src/my_debug.c
+++ b/src/FreeRTOS+FAT+CLI/src/my_debug.c
@@ -204,7 +204,7 @@ int ff_stdio_fail(const char *const func, char const *const str, char const *con
     return error;
 }
 
-void my_assert_func(const char *file, int line, const char *func, const char *pred) {
+void __attribute__((weak)) my_assert_func(const char *file, int line, const char *func, const char *pred) {
     error_message_printf_plain(
         "%s: assertion \"%s\" failed: file \"%s\", line %d, function: %s\n",
         pcTaskGetName(NULL), pred, file, line, func);
@@ -221,7 +221,6 @@ void assert_case_not_func(const char *file, int line, const char *func, int v) {
 }
 
 void assert_case_is(const char *file, int line, const char *func, int v, int expected) {
-    TRIG();  // DEBUG
     char pred[128];
     snprintf(pred, sizeof pred, "%d is %d", v, expected);
     my_assert_func(file, line, func, pred);
@@ -232,10 +231,10 @@ void dump8buf(char *buf, size_t buf_sz, uint8_t *pbytes, size_t nbytes) {
     for (size_t byte_ix = 0; byte_ix < nbytes; ++byte_ix) {
         for (size_t col = 0; col < 32 && byte_ix < nbytes; ++col, ++byte_ix) {
             n += snprintf(buf + n, buf_sz - n, "%02hhx ", pbytes[byte_ix]);
-            configASSERT(0 < n && n < (int)buf_sz);
+            myASSERT(0 < n && n < (int)buf_sz);
         }
         n += snprintf(buf + n, buf_sz - n, "\n");
-        configASSERT(0 < n && n < (int)buf_sz);
+        myASSERT(0 < n && n < (int)buf_sz);
     }
 }
 void hexdump_8(const char *s, const uint8_t *pbytes, size_t nbytes) {

--- a/src/FreeRTOS+FAT+CLI/src/sd_timeouts.c
+++ b/src/FreeRTOS+FAT+CLI/src/sd_timeouts.c
@@ -1,0 +1,19 @@
+
+#include "sd_timeouts.h"
+
+sd_timeouts_t sd_timeouts __attribute__((weak)) = {
+    .sd_command = 2000, // Timeout in ms for response
+    .sd_command_retries = 3, // Times SPI cmd is retried when there is no response
+    .sd_lock = 8000, // Timeout in ms for response
+    .sd_spi_read = 1000, // Timeout in ms for response
+    .sd_spi_write = 1000, // Timeout in ms for response
+    .sd_spi_write_read = 1000, // Timeout in ms for response
+    .spi_lock = 4000, // Timeout in ms for response
+    .rp2040_sdio_command_R1 = 5, // Timeout in ms for response
+    .rp2040_sdio_command_R2 = 2, // Timeout in ms for response
+    .rp2040_sdio_command_R3 = 2, // Timeout in ms for response
+    .rp2040_sdio_rx_poll = 1000, // Timeout in ms for response
+    .rp2040_sdio_tx_poll = 5000, // Timeout in ms for response
+    .sd_sdio_begin = 1000, // Timeout in ms for response
+    .sd_sdio_stopTransmission = 200, // Timeout in ms for response
+};


### PR DESCRIPTION
* Add `spi_mode` to the hardware configuration.
For SPI attached cards, SPI Mode 3 can significantly improve performance.
* Additional performance improvements in SPI driver.
* Make timeouts configurable. See [Timeouts](#timeouts).

Addresses Performance improvement in SPI #27.